### PR TITLE
[Feat] ObjectPooling이용한 서류 재생성 기능 추가

### DIFF
--- a/.idea/.idea.HyperGame_6/.idea/.gitignore
+++ b/.idea/.idea.HyperGame_6/.idea/.gitignore
@@ -1,0 +1,13 @@
+# 디폴트 무시된 파일
+/shelf/
+/workspace.xml
+# Rider에서 무시된 파일
+/projectSettingsUpdater.xml
+/.idea.HyperGame_6.iml
+/modules.xml
+/contentModel.xml
+# 에디터 기반 HTTP 클라이언트 요청
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.HyperGame_6/.idea/indexLayout.xml
+++ b/.idea/.idea.HyperGame_6/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.HyperGame_6/.idea/vcs.xml
+++ b/.idea/.idea.HyperGame_6/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Assets/Scripts/Classification.cs
+++ b/Assets/Scripts/Classification.cs
@@ -14,7 +14,8 @@ public class Classification : Singleton<Classification>
     float feverValue = 0; //피버 게이지
     float scoreMag = 1.0f; //점수 배율
     int score = 0; //점수
-
+    
+    public DocumentController docController;
     public void scoreMagnification()
     {
         switch(combo)
@@ -126,8 +127,10 @@ public class Classification : Singleton<Classification>
                 }
             }
         }
-
+    
         TimeController.Instance._remainedTime = time; // 남은 일과시간 갱신
         TimeController.Instance._day = day; // 남은 진행일수 갱신
+        
+        docController.ReloadDocument(); // 서류 재생성
     }
 }

--- a/Assets/featuer_docSO/Document/Document.cs
+++ b/Assets/featuer_docSO/Document/Document.cs
@@ -1,0 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Document : MonoBehaviour
+{
+    public GameObject OriginalPrefab { get; set; } 
+}

--- a/Assets/featuer_docSO/Document/Document.cs.meta
+++ b/Assets/featuer_docSO/Document/Document.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8ffb835429d104042a11aa713d589f22
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/featuer_docSO/Document/DocumentPool.cs
+++ b/Assets/featuer_docSO/Document/DocumentPool.cs
@@ -1,0 +1,96 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DocumentPool : Singleton<DocumentPool>
+{
+    // 프리팹 별로 큐를 관리하는 딕셔너리
+    private Dictionary<GameObject, Queue<GameObject>> poolDictionary = new Dictionary<GameObject, Queue<GameObject>>();
+
+    // 오브젝트 요청 메서드
+    // prefab: 생성/재사용할 오브젝트의 원본 프리팹
+    // position: 배치할 위치
+    // rotation: 배치할 회전값
+    public GameObject GetObject(GameObject prefab, Vector3 position, Quaternion rotation)
+    {
+        // 해당 프리팹의 큐가 없으면 새로 생성
+        if (!poolDictionary.ContainsKey(prefab))
+        {
+            poolDictionary[prefab] = new Queue<GameObject>();
+        }
+
+        GameObject obj;
+        
+        // 큐가 비어있으면 새로 Instantiate, 아니면 큐에서 꺼내서 재사용
+        if (poolDictionary[prefab].Count == 0)
+        {
+            obj = Instantiate(prefab);
+        }
+        else
+        {
+            obj = poolDictionary[prefab].Dequeue();
+        }
+
+        // 오리지널 프리팹 정보 저장 (되돌릴 때 사용)
+        var obstacleController = obj.GetComponent<ObstacleController>();
+        if (obstacleController != null)
+        {
+            obstacleController.OriginalPrefab = prefab;
+        }
+
+        var rejectController = obj.GetComponent<RejectController>();
+        if (rejectController != null)
+        {
+            rejectController.OriginalPrefab = prefab;
+        }
+        
+        var document = obj.GetComponent<Document>();
+        if (document != null)
+        {
+            document.OriginalPrefab = prefab;
+        }
+        //
+        
+        obj.transform.position = position;
+        obj.transform.rotation = rotation;
+
+        obj.SetActive(true);
+
+        return obj;
+    }
+
+    // 오브젝트 반환 메서드 (비활성화 후 풀에 넣기)
+    public void ReturnObject(GameObject obj)
+    {
+        obj.SetActive(false);
+
+        // 오브젝트에 붙어 있는 스크립트에서 원래의 프리팹 정보 가져오기
+        var obstacleController = obj.GetComponent<ObstacleController>();
+        var rejectController = obj.GetComponent<RejectController>();
+        var document = obj.GetComponent<Document>();
+
+        GameObject prefabKey = null;
+
+        if (obstacleController != null)
+            prefabKey = obstacleController.OriginalPrefab;
+        else if (rejectController != null)
+            prefabKey = rejectController.OriginalPrefab;
+        else if (document != null)
+            prefabKey = document.OriginalPrefab;
+        
+        // 프리팹 정보를 못 찾으면 경고 출력 후 오브젝트 삭제
+        if (prefabKey == null)
+        {
+            Debug.LogWarning("ReturnObject: OriginalPrefab not found on object, destroying.");
+            Destroy(obj);
+            return;
+        }
+
+        // 해당 프리팹의 큐가 없으면 새로 생성
+        if (!poolDictionary.ContainsKey(prefabKey))
+            poolDictionary[prefabKey] = new Queue<GameObject>();
+
+        poolDictionary[prefabKey].Enqueue(obj);
+    }
+
+}

--- a/Assets/featuer_docSO/Document/DocumentPool.cs.meta
+++ b/Assets/featuer_docSO/Document/DocumentPool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 34171d06a32668244934a3dd7566798e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/featuer_docSO/Document/ObstacleController.cs
+++ b/Assets/featuer_docSO/Document/ObstacleController.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 
 public class ObstacleController : MonoBehaviour
 {
+    public GameObject OriginalPrefab { get; set; } 
+    
     private DocumentController _documentController;
     private int _processCount;
 
@@ -44,7 +46,7 @@ public class ObstacleController : MonoBehaviour
                     // DocumentController 쪽 상태 변경
                     _documentController?.ObstacleCleared();
 
-                    Destroy(gameObject);
+                    DocumentPool.Instance.ReturnObject(this.gameObject);
                 }
             }
         }

--- a/Assets/featuer_docSO/Document/RejectController.cs
+++ b/Assets/featuer_docSO/Document/RejectController.cs
@@ -1,0 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RejectController : MonoBehaviour
+{
+    public GameObject OriginalPrefab { get; set; } 
+}

--- a/Assets/featuer_docSO/Document/RejectController.cs.meta
+++ b/Assets/featuer_docSO/Document/RejectController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1e568d78dd26c784687515fb1d8fb3f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/featuer_docSO/Prefabs(test)/DocumentPrefab.prefab
+++ b/Assets/featuer_docSO/Prefabs(test)/DocumentPrefab.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &3289992503802475228
+--- !u!1 &8057628395227924039
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,22 +8,23 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 8015384400029587393}
-  - component: {fileID: 1407498959055875751}
+  - component: {fileID: 3263369497496995696}
+  - component: {fileID: 7573875189014804289}
+  - component: {fileID: 6196675185602253367}
   m_Layer: 0
-  m_Name: DocumentPrefabs
+  m_Name: DocumentPrefab
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &8015384400029587393
+--- !u!4 &3263369497496995696
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3289992503802475228}
+  m_GameObject: {fileID: 8057628395227924039}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
@@ -32,13 +33,13 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1407498959055875751
+--- !u!212 &7573875189014804289
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3289992503802475228}
+  m_GameObject: {fileID: 8057628395227924039}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -72,15 +73,27 @@ SpriteRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingLayer: 0
-  m_SortingOrder: 4
+  m_SortingOrder: 0
   m_Sprite: {fileID: -1083588490, guid: 0ad6d3d1dd8345a4c9f3a06511017176, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1.8, y: 2.56}
+  m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &6196675185602253367
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8057628395227924039}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8ffb835429d104042a11aa713d589f22, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/featuer_docSO/Prefabs(test)/DocumentPrefab.prefab.meta
+++ b/Assets/featuer_docSO/Prefabs(test)/DocumentPrefab.prefab.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 0d8e1ad0ef0f8b446a692668ec109fd8
+guid: 619c00ef83ba1a94b8debdfef0cc7380
 PrefabImporter:
   externalObjects: {}
   userData: 

--- a/Assets/featuer_docSO/Prefabs(test)/rejectObj/coffee.prefab
+++ b/Assets/featuer_docSO/Prefabs(test)/rejectObj/coffee.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1394134146815866716}
   - component: {fileID: 1404553056799581593}
+  - component: {fileID: -8137229455129299568}
   m_Layer: 0
   m_Name: coffee
   m_TagString: Untagged
@@ -84,3 +85,15 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &-8137229455129299568
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4085532528814942462}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e568d78dd26c784687515fb1d8fb3f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/featuer_docSO/Prefabs(test)/rejectObj/doodle.prefab
+++ b/Assets/featuer_docSO/Prefabs(test)/rejectObj/doodle.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1799957697143528635}
   - component: {fileID: 4454810464409411252}
+  - component: {fileID: -6355831945879091791}
   m_Layer: 0
   m_Name: doodle
   m_TagString: Untagged
@@ -84,3 +85,15 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &-6355831945879091791
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8087392837858221209}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e568d78dd26c784687515fb1d8fb3f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/featuer_docSO/Prefabs(test)/rejectObj/ink.prefab
+++ b/Assets/featuer_docSO/Prefabs(test)/rejectObj/ink.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5583991190308732089}
   - component: {fileID: 1496260506999137308}
+  - component: {fileID: -8197987935703630896}
   m_Layer: 0
   m_Name: ink
   m_TagString: Untagged
@@ -84,3 +85,15 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &-8197987935703630896
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4856289768420295286}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e568d78dd26c784687515fb1d8fb3f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/featuer_docSO/Prefabs(test)/rejectObj/printx.prefab
+++ b/Assets/featuer_docSO/Prefabs(test)/rejectObj/printx.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8236437927179926004}
   - component: {fileID: 5742317365564050366}
+  - component: {fileID: 1164378844698266823}
   m_Layer: 0
   m_Name: printx
   m_TagString: Untagged
@@ -84,3 +85,15 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &1164378844698266823
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5548518695324985368}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e568d78dd26c784687515fb1d8fb3f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/featuer_docSO/Prefabs(test)/rejectObj/water.prefab
+++ b/Assets/featuer_docSO/Prefabs(test)/rejectObj/water.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1891630280125674698}
   - component: {fileID: 643438869001018766}
+  - component: {fileID: 8208851676887703263}
   m_Layer: 0
   m_Name: water
   m_TagString: Untagged
@@ -84,3 +85,15 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &8208851676887703263
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5295545704364293337}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1e568d78dd26c784687515fb1d8fb3f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 


### PR DESCRIPTION
ObjectPooling이용한 서류 재생성 기능 추가

---
name: Merge request
about: PR 템플릿
title: "[REVIEW] "
labels: review
assignees: ""
---

### 변경 사항

1. 오브젝트 풀 디자인을 사용하기 위한 스크립트 (DocumentPool.cs)
2. 각 프리팹들이 알맞게 본인 풀에 들어갈 수 있게 오리지널 프리팹의 정보를 저장할 수 있는 컴포넌트 스크립트 추가 (Document.cs, RejectController.cs)
3. 서류 재생성 메서드를 DocumentController 스크립트에 추가
4. 서류를 분류하면 재생성 메서드를 호출할 수 있게 Classification 수정

### 관련 이슈
Closes #4

### 테스트 항목
- [ y] 게임플레이 테스트 완료
- [ ] 빌드 테스트

### 스크린샷/동영상
[변경사항을 시각적으로 보여줄 수 있는 자료를 첨부해주세요]

### 코드 리뷰 체크리스트
- [ y] 코드 스타일 가이드 준수
- [ ] 불필요한 디버그 로그 제거
- [ ] 성능 최적화 고려
- [ ] 예외 처리 구현
- [ y] 주석 작성

### 추가 노트
DocumentController.cs에 Start()메서드가 테스트용 메서드입니다. 추후 기능 통합시 지워야합니다.