### PR TITLE
[Feat] New Record시, 점수판 위에 Image로 표시 & 점수판 Image 누락 수정

### DIFF
--- a/Assets/Prefab/UI/InGame/ScoreUI.prefab
+++ b/Assets/Prefab/UI/InGame/ScoreUI.prefab
@@ -34,7 +34,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 72, y: -66.9}
+  m_AnchoredPosition: {x: 72, y: -70.9}
   m_SizeDelta: {x: 320, y: 80}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &7465746903171198086
@@ -163,6 +163,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 2076097780566538003}
+  - {fileID: 2611625538267013711}
   - {fileID: 8980828133469082756}
   - {fileID: 7736737996679558680}
   - {fileID: 845267175188791466}
@@ -182,6 +184,81 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 960445236220756476}
   m_CullTransparentMesh: 1
+--- !u!1 &1544351043798126922
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2076097780566538003}
+  - component: {fileID: 7616514046578838102}
+  - component: {fileID: 4542045892361135089}
+  m_Layer: 5
+  m_Name: ScoreImage_2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2076097780566538003
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1544351043798126922}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1219795602023773436}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 650, y: 275}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7616514046578838102
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1544351043798126922}
+  m_CullTransparentMesh: 1
+--- !u!114 &4542045892361135089
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1544351043798126922}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 64b9d0231fc92ae478fa25fe2e3aa394, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &3257866823966823521
 GameObject:
   m_ObjectHideFlags: 0
@@ -216,7 +293,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: -190, y: -101}
+  m_AnchoredPosition: {x: -190, y: -105}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &7665320313618796679
@@ -353,6 +430,81 @@ RectTransform:
   m_AnchoredPosition: {x: -135, y: -177}
   m_SizeDelta: {x: 728, y: 128}
   m_Pivot: {x: 0.5, y: 1}
+--- !u!1 &4962264552009662122
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2611625538267013711}
+  - component: {fileID: 2756693083108896396}
+  - component: {fileID: 3697300640051938155}
+  m_Layer: 5
+  m_Name: NewRecordImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2611625538267013711
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4962264552009662122}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1219795602023773436}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 1}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: 58}
+  m_SizeDelta: {x: 650, y: 275}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &2756693083108896396
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4962264552009662122}
+  m_CullTransparentMesh: 1
+--- !u!114 &3697300640051938155
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4962264552009662122}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: cda3151c66e3bf34f800ba6b8c05b43e, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &5282089894202605215
 GameObject:
   m_ObjectHideFlags: 0
@@ -502,6 +654,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   score: {fileID: 5362145776864407183}
   scoreMag: {fileID: 3621749003700807477}
+  newRecordImage: {fileID: 3697300640051938155}
 --- !u!114 &7174011876880507376
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -527,7 +680,7 @@ GameObject:
   - component: {fileID: 7359110078423157829}
   - component: {fileID: 3015306932491653734}
   m_Layer: 5
-  m_Name: Image
+  m_Name: ScoreImage_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -549,7 +702,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0, y: 64}
+  m_AnchoredPosition: {x: 0, y: 58}
   m_SizeDelta: {x: 650, y: 275}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!222 &7359110078423157829

--- a/Assets/Script/Managers/GameStates/InGameState.cs
+++ b/Assets/Script/Managers/GameStates/InGameState.cs
@@ -16,7 +16,12 @@ public class InGameState : IGameState
     
     public void OnUpdate()
     {
-        
+        // TODO: 유저의 최고기록 불러오기 (임시: 'K'를 누르면 연출 재생)
+        // New Record시, 점수판에 New Record Image 연출 재생
+        if (Input.GetKeyDown(KeyCode.K))
+        {
+            InGameUIController.Instance.scoreUIController.ShowNewRecordImage();
+        }
     }
     
     public void OnExit()

--- a/Assets/Script/Managers/InGameController.cs
+++ b/Assets/Script/Managers/InGameController.cs
@@ -80,6 +80,9 @@ public class InGameController
         //classification.InitScore();
         GameManager.Instance.GetClassification().InitScore();
         _initComplete = true;
+        
+        // NewRecord 이미지 위치 초기화
+        InGameUIController.Instance.scoreUIController.InitNewRecordImage();
     }
 
     

--- a/Assets/Script/UI/InGameUI/ScoreUIController.cs
+++ b/Assets/Script/UI/InGameUI/ScoreUIController.cs
@@ -2,9 +2,28 @@ using System.Collections;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
+using DG.Tweening;
 
 public class ScoreUIController : MonoBehaviour
 {
     public TMP_Text score;
     public TMP_Text scoreMag;
+    [SerializeField] private Image newRecordImage;
+    private readonly float _hiddenY = 23f;   // Unity에서 위치를 보고 맞춘 값
+    private readonly float _shownY = 58f;   // Unity에서 위치를 보고 맞춘 값
+
+    // New Record 이미지 위치 초기화
+    public void InitNewRecordImage()
+    {
+        Vector2 newRecordPos = newRecordImage.rectTransform.anchoredPosition;
+        newRecordPos.y = _hiddenY;
+        newRecordImage.rectTransform.anchoredPosition = newRecordPos;
+    }
+
+    // New Record Animation
+    public void ShowNewRecordImage()
+    {
+        newRecordImage.rectTransform.DOAnchorPosY(_shownY, 0.3f).SetEase(Ease.OutBack);
+    }
 }


### PR DESCRIPTION
- 처음에는 New Record Image가 점수판 안에 들어가 있다가 New Record시 위로 튀어오르도록
- 아직 리더보드가 구현되어 있지 않으므로 'K' 버튼을 누르면 효과가 나타나도록 임시 적용
- 점수판 Image에서 'Score_03' Image가 적용되어 있지 않는 걸 발견, 적용 완료

---
name: Merge request
about: PR 템플릿
title: "[REVIEW] "
labels: review
assignees: ""
---

### 변경 사항
- 처음에는 New Record Image가 점수판 안에 들어가 있다가 New Record시 위로 튀어오르도록
- 아직 리더보드가 구현되어 있지 않으므로 'K' 버튼을 누르면 효과가 나타나도록 임시 적용
- 점수판 Image에서 'Score_03' Image가 적용되어 있지 않는 걸 발견, 적용 완료

### 관련 이슈
Closes #79 

### 테스트 항목
- [x] 게임플레이 테스트 완료
- [ ] 빌드 테스트

### 스크린샷/동영상
[변경사항을 시각적으로 보여줄 수 있는 자료를 첨부해주세요]

### 코드 리뷰 체크리스트
- [x] 코드 스타일 가이드 준수
- [x] 불필요한 디버그 로그 제거
- [ ] 성능 최적화 고려
- [ ] 예외 처리 구현
- [x] 주석 작성

### 추가 노트
[리뷰어가 알아야 할 추가 정보를 작성해주세요]
