### PR TITLE
[Feat] SFXController 리팩토링 및 BGM 버그 수정

### DIFF
--- a/Assets/@KYJ/ClockUIController.cs
+++ b/Assets/@KYJ/ClockUIController.cs
@@ -43,6 +43,8 @@ public class ClockUIController : MonoBehaviour
         clockHandle.transform.rotation = Quaternion.Lerp(clockHandle.transform.rotation, Quaternion.Euler(0, 0, targetZ), Time.deltaTime * 10f);
     }
 
+    private bool _isAlert;
+    
     public void ClockFrameColor() // 시계 프레임 색상 변경 기능
     {
         float remainedTime = TimeController.Instance._remainedTimerTime;
@@ -55,9 +57,17 @@ public class ClockUIController : MonoBehaviour
             clockFrame.color = Color.Lerp(customGreen, Color.red, t); // 흰색에서 빨간색으로 보간
 
             /* SFX, VFX 등 추가할거 있으면 여기에 추가 및 수정하시면 됩니다 */
+            if (!_isAlert)
+            {
+                _isAlert = true;
+                AudioManager.Instance.SFX.PlayTimeOutAlert();
+            }
         }
         else
         {
+            if (_isAlert)
+                AudioManager.Instance.SFX.StopTimeOutAlert();
+            _isAlert = false;
             InitClockFrameColor(); // 기본 색상으로 설정
         }
     }

--- a/Assets/Script/Audio/SFXController.cs
+++ b/Assets/Script/Audio/SFXController.cs
@@ -27,23 +27,30 @@ public class SFXController : Singleton<SFXController>
     
     // 여기까지
 
-    private AudioSource _sfxSource;
+    private AudioSource _sfxSource;                             // 단발성 AudioSource
+    private Dictionary<AudioClip, AudioSource> _loopSources;    // 반복용 AudioSource
     private bool _isSFXOn = true;       // SFX가 켜져있는지 여부
-    public bool IsSFXOn() => _isSFXOn;
+    public bool GetIsSFXOn() => _isSFXOn;
     
     protected override void Initialize()
     {
         SceneManager.sceneLoaded += OnSceneLoaded;
+        
+        // AudioSource 초기화
         _sfxSource = gameObject.AddComponent<AudioSource>();
+        _sfxSource.playOnAwake = false;
+        _loopSources = new Dictionary<AudioClip, AudioSource>();
     }
 
     private void OnSceneLoaded(Scene scene, LoadSceneMode loadSceneMode)
     {
-        //SceneManager.sceneLoaded -= OnSceneLoaded;
         AudioManager.Instance.SetSFXController(this);
     }
 
     // SFX를 추가하신 뒤, 아래 함수 모음에 재생 함수를 작성해주세요. 그리고 작성하신 함수를 통해 사용하시면 됩니다.
+    // 1번 재생 : PlaySFX()
+    // 반복 재생 : PlayLoopSFX()
+    // 반복 재생 중지 : StopLoopSFX()
     #region PlaySFX 함수 모음
 
     public void PlayButtonClick() => PlaySFX(buttonClick);
@@ -59,7 +66,8 @@ public class SFXController : Singleton<SFXController>
     public void PlayObsFileEnvelopeOut() => PlaySFX(obsFileEnvelopeOut);
     public void PlaySpeedUp() => PlaySFX(speedUp);
     public void PlayFever() => PlaySFX(fever);
-    public void PlayTimeOutAlert() => PlaySFX(timeOutAlert);
+    public void PlayTimeOutAlert() => PlayLoopSFX(timeOutAlert);
+    public void StopTimeOutAlert() => StopLoopSFX(timeOutAlert);
     public void PlayNewRecordResult() => PlaySFX(newRecordResult);
     public void PlayNewRecordScoreBar() => PlaySFX(newRecordScoreBar);
     #endregion
@@ -70,10 +78,48 @@ public class SFXController : Singleton<SFXController>
         if (!_isSFXOn || clip == null) return;
         _sfxSource.PlayOneShot(clip);
     }
+    
+    // SFX 반복 재생
+    private void PlayLoopSFX(AudioClip clip)
+    {
+        if (!_isSFXOn || clip == null) return;
+        if (_loopSources.ContainsKey(clip)) return;     // 이미 재생 중이면 패스
+        
+        var src = gameObject.AddComponent<AudioSource>();
+        src.playOnAwake = false;
+        src.loop = true;
+        src.clip = clip;
+        src.Play();
+        _loopSources[clip] = src;
+    }
+    
+    // SFX 반복 재생 중지
+    private void StopLoopSFX(AudioClip clip)
+    {
+        if (clip == null || !_loopSources.ContainsKey(clip)) return;
+
+        var src = _loopSources[clip];
+        if (src != null && src.isPlaying)
+        {
+            src.Stop();
+            Destroy(src);
+        }
+        _loopSources.Remove(clip);
+    }
 
     // _isSFXOn 조정
     public void SetSFXOn(bool isSFXOn)
     {
         _isSFXOn = isSFXOn;
+
+        if (!_isSFXOn)  // 모든 SFX 정지
+        {
+            _sfxSource.Stop();
+            
+            foreach (var key in _loopSources)
+                if (key.Value != null) key.Value.Stop();
+            
+            _loopSources.Clear();
+        }
     }
 }

--- a/Assets/Script/Managers/GameStates/InGameState.cs
+++ b/Assets/Script/Managers/GameStates/InGameState.cs
@@ -9,9 +9,6 @@ public class InGameState : IGameState
     { 
        GameManager.Instance.StartCoroutine(StartGame());
        UIManager.Instance.inGameUIController.ShowInGameUI();
-       
-       // BGM 재생
-       AudioManager.Instance.BGM.PlayBGMByState(GameManager.Instance.GetGameState());
     }
     
     public void OnUpdate()

--- a/Assets/Script/Managers/InGameController.cs
+++ b/Assets/Script/Managers/InGameController.cs
@@ -133,6 +133,8 @@ public class InGameController
         //시간 정지
         timeController.StopTime();
         
+        // 시간 부족 SFX 반복 재생 중지
+        AudioManager.Instance.SFX.StopTimeOutAlert();
         
         //ex.게임오버 연출, 결과창UI등
         


### PR DESCRIPTION
- SFX 중에 반복재생이 필요한 SFX는 반복재생 및 중지가 가능하도록 수정
- BGM이 게임 시작을 눌렀을 때 + 3초 카운팅 뒤 게임이 시작할 때 두번 재생되던 버그 수정
- 게임 결과창이 나올 때도 게임을 다시 시작하기 전까지 계속 반복SFX가 재생되던 버그 수정

---
name: Merge request
about: PR 템플릿
title: "[REVIEW] "
labels: review
assignees: ""
---

### 변경 사항
- SFX 중에 반복재생이 필요한 SFX는 반복재생 및 중지가 가능하도록 수정
- BGM이 게임 시작을 눌렀을 때 + 3초 카운팅 뒤 게임이 시작할 때 두번 재생되던 버그 수정
- 게임 결과창이 나올 때도 게임을 다시 시작하기 전까지 계속 반복SFX가 재생되던 버그 수정

### 관련 이슈
Closes #105 

### 테스트 항목
- [ ] 게임플레이 테스트 완료
- [ ] 빌드 테스트

### 스크린샷/동영상
[변경사항을 시각적으로 보여줄 수 있는 자료를 첨부해주세요]

### 코드 리뷰 체크리스트
- [ ] 코드 스타일 가이드 준수
- [ ] 불필요한 디버그 로그 제거
- [ ] 성능 최적화 고려
- [ ] 예외 처리 구현
- [ ] 주석 작성

### 추가 노트
[리뷰어가 알아야 할 추가 정보를 작성해주세요]
